### PR TITLE
Add `full` extras to install command in contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ To develop PyG on your machine, here are some tips:
 4. Install PyG in editable mode:
 
    ```bash
-   pip install -e .[dev]
+   pip install -e .[dev,full]
    ```
 
    This mode will symlink the Python files from the current local source tree into the Python install. Hence, if you modify a Python file, you do not need to reinstall PyG again and again.


### PR DESCRIPTION
For the tests, the full installs packages are required. 